### PR TITLE
Change phpunit namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction
+  - composer update --prefer-source --no-interaction
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 language: php
- 
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
   - hhvm
   - hhvm-nightly
 
 matrix:
   fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
-    - php: 7
+    - php: nightly
     - php: hhvm
     - php: hhvm-nightly
 
 before_script:
   - composer self-update
-  - composer install --dev --prefer-source --no-interaction
+  - composer install --prefer-source --no-interaction
 
 script:
   - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "^4.8 || ^5.5 || ^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/BigNumberAbsTest.php
+++ b/tests/BigNumberAbsTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberAbsTest extends PHPUnit_Framework_TestCase
+class BigNumberAbsTest extends TestCase
 {
     public function testWithNegativeFloat()
     {

--- a/tests/BigNumberAddTest.php
+++ b/tests/BigNumberAddTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberAddTest extends PHPUnit_Framework_TestCase
+class BigNumberAddTest extends TestCase
 {
     public function testWithBigNumber()
     {

--- a/tests/BigNumberConstructorTest.php
+++ b/tests/BigNumberConstructorTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberConstructorTest extends PHPUnit_Framework_TestCase
+class BigNumberConstructorTest extends TestCase
 {
     public function testEmpty()
     {

--- a/tests/BigNumberDivideTest.php
+++ b/tests/BigNumberDivideTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberDivideTest extends PHPUnit_Framework_TestCase
+class BigNumberDivideTest extends TestCase
 {
     public function testWithBigNumber()
     {

--- a/tests/BigNumberIsMutableTest.php
+++ b/tests/BigNumberIsMutableTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberIsMutableTest extends PHPUnit_Framework_TestCase
+class BigNumberIsMutableTest extends TestCase
 {
     public function testIsMutableEmpty()
     {

--- a/tests/BigNumberModTest.php
+++ b/tests/BigNumberModTest.php
@@ -3,9 +3,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberModTest extends PHPUnit_Framework_TestCase
+class BigNumberModTest extends TestCase
 {
     public function testWithBigNumber()
     {

--- a/tests/BigNumberMultiplyTest.php
+++ b/tests/BigNumberMultiplyTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberMultiplyTest extends PHPUnit_Framework_TestCase
+class BigNumberMultiplyTest extends TestCase
 {
     public function testWithBigNumber()
     {

--- a/tests/BigNumberPowTest.php
+++ b/tests/BigNumberPowTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberPowTest extends PHPUnit_Framework_TestCase
+class BigNumberPowTest extends TestCase
 {
     /**
      * @expectedException InvalidArgumentException

--- a/tests/BigNumberSetScaleTest.php
+++ b/tests/BigNumberSetScaleTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberSetScaleTest extends PHPUnit_Framework_TestCase
+class BigNumberSetScaleTest extends TestCase
 {
     /**
      * @expectedException InvalidArgumentException

--- a/tests/BigNumberSetValueTest.php
+++ b/tests/BigNumberSetValueTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberSetValueTest extends PHPUnit_Framework_TestCase
+class BigNumberSetValueTest extends TestCase
 {
     public function testWithInteger()
     {

--- a/tests/BigNumberSqrtTest.php
+++ b/tests/BigNumberSqrtTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberSqrtTest extends PHPUnit_Framework_TestCase
+class BigNumberSqrtTest extends TestCase
 {
     public function testSqrt()
     {

--- a/tests/BigNumberSubtractTest.php
+++ b/tests/BigNumberSubtractTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BigNumberSubtractTest extends PHPUnit_Framework_TestCase
+class BigNumberSubtractTest extends TestCase
 {
     public function testWithBigNumber()
     {

--- a/tests/UtilsConvertBaseTest.php
+++ b/tests/UtilsConvertBaseTest.php
@@ -11,9 +11,9 @@ namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
 use PHP\Math\BigNumber\Utils;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilsConvertBaseTest extends PHPUnit_Framework_TestCase
+class UtilsConvertBaseTest extends TestCase
 {
     /**
      * @expectedException RuntimeException

--- a/tests/UtilsConvertExponentialToStringTest.php
+++ b/tests/UtilsConvertExponentialToStringTest.php
@@ -10,9 +10,9 @@
 namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\Utils;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilsConvertExponentialToStringTest extends PHPUnit_Framework_TestCase
+class UtilsConvertExponentialToStringTest extends TestCase
 {
     public function testFloat()
     {

--- a/tests/UtilsConvertToBase10Test.php
+++ b/tests/UtilsConvertToBase10Test.php
@@ -11,9 +11,9 @@ namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
 use PHP\Math\BigNumber\Utils;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilsConvertToBase10Test extends PHPUnit_Framework_TestCase
+class UtilsConvertToBase10Test extends TestCase
 {
     /**
      * @expectedException RuntimeException

--- a/tests/UtilsGetPlainNumberTest.php
+++ b/tests/UtilsGetPlainNumberTest.php
@@ -11,9 +11,9 @@ namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
 use PHP\Math\BigNumber\Utils;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilsGetPlainNumberTest extends PHPUnit_Framework_TestCase
+class UtilsGetPlainNumberTest extends TestCase
 {
     public function testGetPlainNumberWithBigNumber()
     {

--- a/tests/UtilsMultiplyTest.php
+++ b/tests/UtilsMultiplyTest.php
@@ -11,9 +11,9 @@ namespace PHP\Math\BigNumberTest;
 
 use PHP\Math\BigNumber\BigNumber;
 use PHP\Math\BigNumber\Utils;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilsMultiplyTest extends PHPUnit_Framework_TestCase
+class UtilsMultiplyTest extends TestCase
 {
     public function testMultiply()
     {


### PR DESCRIPTION
# Changed log

- Use the class-based PHPUnit namespace.
- Use the correct settings  in ```.travis.yml```.
- Set the different PHPUnit versions are for the different PHP versions.